### PR TITLE
fix auto interval

### DIFF
--- a/grafana/board.go
+++ b/grafana/board.go
@@ -69,6 +69,7 @@ type (
 	templateVar struct {
 		Name        string   `json:"name"`
 		Type        string   `json:"type"`
+		Auto        bool     `json:"auto,omitempty"`
 		AutoCount   *int     `json:"auto_count,omitempty"`
 		Datasource  *string  `json:"datasource"`
 		Refresh     bool     `json:"refresh"`


### PR DESCRIPTION
without this key the checkbox "Include auto interval" for the variable in templating is not marked and the behavior of interval variable is corrupted.

![auto_interval](https://cloud.githubusercontent.com/assets/1011632/15769167/98962f18-2982-11e6-90fa-2080f9e3ce65.png)
